### PR TITLE
fix: incorrect metaculus base_url

### DIFF
--- a/forecast_bot.py
+++ b/forecast_bot.py
@@ -240,7 +240,7 @@ async def main():
         "--metac_base_url",
         type=str,
         help="The base URL for the metaculus API",
-        default=config("API_BASE_URL", default="https://metaculus.com/api2", cast=str),
+        default=config("API_BASE_URL", default="https://www.metaculus.com/api2", cast=str),
     )
     parser.add_argument(
         "--tournament_id",


### PR DESCRIPTION
I wondered why my bot couldnt post predictions/comments. Turns out the base_url needs to have the `www.`

Fixing it so other people don't run into this.