### PR TITLE
Redirect test_questions workflow to bot-testing-area tournament

### DIFF
--- a/main.py
+++ b/main.py
@@ -710,19 +710,12 @@ if __name__ == "__main__":
             )
         )
     elif run_mode == "test_questions":
-        # Example questions are a good way to test the bot's performance on a single question
-        EXAMPLE_QUESTIONS = [
-            "https://www.metaculus.com/questions/578/human-extinction-by-2100/",  # Human Extinction - Binary
-            "https://www.metaculus.com/questions/14333/age-of-oldest-human-as-of-2100/",  # Age of Oldest Human - Numeric
-            "https://www.metaculus.com/questions/22427/number-of-new-leading-ai-labs/",  # Number of New Leading AI Labs - Multiple Choice
-            "https://www.metaculus.com/c/diffusion-community/38880/how-many-us-labor-strikes-due-to-ai-in-2029/",  # Number of US Labor Strikes Due to AI in 2029 - Discrete
-        ]
+        # The bot-testing-area tournament contains binary, numeric, multiple choice, and discrete question types
+        # https://www.metaculus.com/tournament/bot-testing-area/
         template_bot.skip_previously_forecasted_questions = False
-        questions = [
-            client.get_question_by_url(question_url)
-            for question_url in EXAMPLE_QUESTIONS
-        ]
         forecast_reports = asyncio.run(
-            template_bot.forecast_questions(questions, return_exceptions=True)
+            template_bot.forecast_on_tournament(
+                "bot-testing-area", return_exceptions=True
+            )
         )
     template_bot.log_report_summary(forecast_reports)

--- a/main.py
+++ b/main.py
@@ -35,9 +35,9 @@ dotenv.load_dotenv()
 logger = logging.getLogger(__name__)
 
 
-class SpringTemplateBot2026(ForecastBot):
+class SummerTemplateBot2026(ForecastBot):
     """
-    This is the template bot for Spring 2026 Metaculus AI Tournament.
+    This is the template bot for Summer 2026 Metaculus AI Tournament.
     This is a copy of what is used by Metaculus to run the Metac Bots in our benchmark, provided as a template for new bot makers.
     This template is given as-is, and is use-at-your-own-risk.
     We have covered most test cases in forecasting-tools it may be worth double checking key components locally.
@@ -46,7 +46,7 @@ class SpringTemplateBot2026(ForecastBot):
     Main changes since Fall:
     - Additional prompting has been added to numeric questions to emphasize putting pecentile values in the correct order.
     - Support for conditional and date questions has been added
-    - Note: Spring AIB will not use date/conditional questions, so these are only for forecasting on the main site as you wish.
+    - Note: Summer AIB will not use date/conditional questions, so these are only for forecasting on the main site as you wish.
 
     The main entry point of this bot is `bot.forecast_on_tournament(tournament_id)` in the parent class.
     See the script at the bottom of the file for more details on how to run the bot.
@@ -665,7 +665,7 @@ if __name__ == "__main__":
         "test_questions",
     ], "Invalid run mode"
 
-    template_bot = SpringTemplateBot2026(
+    template_bot = SummerTemplateBot2026(
         research_reports_per_question=1,
         predictions_per_research_report=5,
         use_research_summary_to_forecast=False,

--- a/main_with_no_framework.py
+++ b/main_with_no_framework.py
@@ -49,7 +49,7 @@ Updates pending for Spring season:
 ######################### CONSTANTS #########################
 # Constants
 SUBMIT_PREDICTION = True  # set to True to publish your predictions to Metaculus
-USE_EXAMPLE_QUESTIONS = False  # set to True to forecast example questions rather than the tournament questions
+USE_EXAMPLE_QUESTIONS = False  # set to True to forecast on the bot-testing-area tournament instead of TOURNAMENT_ID
 NUM_RUNS_PER_QUESTION = (
     5  # The median forecast is taken between NUM_RUNS_PER_QUESTION runs
 )
@@ -82,27 +82,11 @@ CURRENT_METACULUS_CUP_ID = None # TBD (Use the slug from the Metaculus Cup URL)
 AXC_2025_TOURNAMENT_ID = 32564
 AI_2027_TOURNAMENT_ID = "ai-2027"
 
-TOURNAMENT_ID = SUMMER_2026_AI_BENCHMARKING_ID
+# Bot Testing Area - contains all question types and is the recommended target for test runs.
+# https://www.metaculus.com/tournament/bot-testing-area/
+BOT_TESTING_AREA_ID = "bot-testing-area"
 
-# The example questions can be used for testing your bot. (note that question and post id are not always the same)
-EXAMPLE_QUESTIONS = [  # (question_id, post_id)
-    (
-        578,
-        578,
-    ),  # Human Extinction - Binary - https://www.metaculus.com/questions/578/human-extinction-by-2100/
-    (
-        14333,
-        14333,
-    ),  # Age of Oldest Human - Numeric - https://www.metaculus.com/questions/14333/age-of-oldest-human-as-of-2100/
-    (
-        22427,
-        22427,
-    ),  # Number of New Leading AI Labs - Multiple Choice - https://www.metaculus.com/questions/22427/number-of-new-leading-ai-labs/
-    (
-        38195,
-        38880,
-    ),  # Number of US Labor Strikes Due to AI in 2029 - Discrete - https://www.metaculus.com/c/diffusion-community/38880/how-many-us-labor-strikes-due-to-ai-in-2029/
-]
+TOURNAMENT_ID = SUMMER_2026_AI_BENCHMARKING_ID
 
 
 ######################### HELPER FUNCTIONS #########################
@@ -215,8 +199,10 @@ def list_posts_from_tournament(
     return data
 
 
-def get_open_question_ids_from_tournament() -> list[tuple[int, int]]:
-    posts = list_posts_from_tournament()
+def get_open_question_ids_from_tournament(
+    tournament_id: int | str = TOURNAMENT_ID,
+) -> list[tuple[int, int]]:
+    posts = list_posts_from_tournament(tournament_id)
 
     post_dict = dict()
     for post in posts["results"]:
@@ -1534,10 +1520,8 @@ async def forecast_questions(
 
 ######################## FINAL RUN #########################
 if __name__ == "__main__":
-    if USE_EXAMPLE_QUESTIONS:
-        open_question_id_post_id = EXAMPLE_QUESTIONS
-    else:
-        open_question_id_post_id = get_open_question_ids_from_tournament()
+    active_tournament_id = BOT_TESTING_AREA_ID if USE_EXAMPLE_QUESTIONS else TOURNAMENT_ID
+    open_question_id_post_id = get_open_question_ids_from_tournament(active_tournament_id)
 
     asyncio.run(
         forecast_questions(

--- a/main_with_no_framework.py
+++ b/main_with_no_framework.py
@@ -126,6 +126,7 @@ def post_question_prediction(question_id: int, forecast_payload: dict) -> None:
         json=[
             {
                 "question": question_id,
+                "source": "api",
                 **forecast_payload,
             },
         ],

--- a/main_with_no_framework.py
+++ b/main_with_no_framework.py
@@ -49,7 +49,7 @@ Updates pending for Spring season:
 ######################### CONSTANTS #########################
 # Constants
 SUBMIT_PREDICTION = True  # set to True to publish your predictions to Metaculus
-USE_EXAMPLE_QUESTIONS = False  # set to True to forecast on the bot-testing-area tournament instead of TOURNAMENT_ID
+USE_EXAMPLE_QUESTIONS = False  # set to True to forecast on the bot-testing-area tournament 
 NUM_RUNS_PER_QUESTION = (
     5  # The median forecast is taken between NUM_RUNS_PER_QUESTION runs
 )


### PR DESCRIPTION
- Replace the hard-coded `EXAMPLE_QUESTIONS` URL list in `main.py` with `forecast_on_tournament("bot-testing-area", ...)` for the `--mode test_questions` workflow path

- Add `BOT_TESTING_AREA_ID = "bot-testing-area"` constant in `main_with_no_framework.py` and route the existing `USE_EXAMPLE_QUESTIONS` toggle to it (replacing the hard-coded `(question_id, post_id)` list)

- Thread `tournament_id` through `get_open_question_ids_from_tournament` so the toggle can switch between the production tournament and bot-testing-area without mutating module globals
