### PR TITLE
[Bootstrap] Psychohistory harness integration

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -12,3 +12,9 @@ ANTHROPIC_API_KEY=1234567890
 
 # Integrations
 LIGHTNINGROD_API_KEY=1234567890
+PSYCHOHISTORY_OUTPUT_DIR=/absolute/path/to/template-runs
+
+# Optional alias used by some tooling
+ASKNEWS_API_KEY=
+METACULUS_API_TOKEN=
+

--- a/README.md
+++ b/README.md
@@ -169,6 +169,18 @@ These tags are likely useful for extracting the pieces that you need for your pi
 
 ## Integrations
 
+### Psychohistory Harness (optional)
+
+Set `PSYCHOHISTORY_OUTPUT_DIR` in your `.env` to automatically export forecast
+runs as JSONL for ingestion into the psychohistory memory harness:
+
+```bash
+PSYCHOHISTORY_OUTPUT_DIR=/path/to/psychohistory/data/template-runs
+```
+
+Runs are written to `$PSYCHOHISTORY_OUTPUT_DIR/runs-YYYY-MM-DD.jsonl`.
+See `docs/psychohistory-bootstrap.md` for the full sync flow.
+
 The **[integrations/](integrations/)** folder contains example scripts that integrate third-party tools with the bot template. 
 
 See the [integrations README](integrations/README.md) for available integrations and how to add your own.

--- a/docs/psychohistory-bootstrap.md
+++ b/docs/psychohistory-bootstrap.md
@@ -1,0 +1,66 @@
+# Psychohistory bootstrap notes (two-repo split)
+
+This repo is the live AIB posting bot (Metaculus template).
+Keep psychohistory harness in its own repo for memory/Brier research loops.
+
+## 1) Env setup
+
+```bash
+cp .env.template .env
+```
+
+Set at least:
+- `METACULUS_TOKEN`
+- `OPENROUTER_API_KEY` (free-credit path)
+- `ASKNEWS_CLIENT_ID`
+- `ASKNEWS_SECRET`
+- `PSYCHOHISTORY_OUTPUT_DIR` (absolute path in psychohistory repo, e.g. `/Users/darenpalmer/conductor/workspaces/psychohistory-v2/aib-live-next-steps/data/template-runs`)
+
+Compatibility aliases included:
+- `METACULUS_API_TOKEN`
+- `ASKNEWS_API_KEY`
+
+## 2) Install + smoke test
+
+```bash
+poetry install
+poetry run python main.py --mode test_questions
+```
+
+## 3) Live run + export
+
+```bash
+poetry run python main.py --mode tournament
+```
+
+When `PSYCHOHISTORY_OUTPUT_DIR` is set, successful forecast reports are appended to:
+- `runs-YYYY-MM-DD.jsonl`
+
+If the env var is not set, export is skipped and template behavior is unchanged.
+
+## 4) Sync into psychohistory memory
+
+In psychohistory repo:
+
+```bash
+python -m scripts.sync_template_runs \
+  --template-output-dir /Users/darenpalmer/conductor/workspaces/psychohistory-v2/aib-live-next-steps/data/template-runs \
+  --memory-dir /Users/darenpalmer/conductor/workspaces/psychohistory-v2/aib-live-next-steps/.harness_memory
+```
+
+This writes `EpisodicRecord`s into `JsonlMemoryStore` idempotently.
+
+## 5) Resolution/Brier updates
+
+Run sync again after outcomes appear in exported rows (when `resolved_outcome` is present), or enrich outcome fields before sync. The sync script calls `resolve_market()` and writes Brier scores idempotently.
+
+## 6) GitHub Actions (recommended)
+- Fork this repo to your account.
+- Add secrets in GitHub Actions settings:
+  - `METACULUS_TOKEN`
+  - `OPENROUTER_API_KEY`
+  - `ASKNEWS_CLIENT_ID`
+  - `ASKNEWS_SECRET`
+- Add variable/secret:
+  - `PSYCHOHISTORY_OUTPUT_DIR`
+- Enable workflow and run once manually.

--- a/docs/psychohistory-bootstrap.md
+++ b/docs/psychohistory-bootstrap.md
@@ -54,7 +54,12 @@ This writes `EpisodicRecord`s into `JsonlMemoryStore` idempotently.
 
 Run sync again after outcomes appear in exported rows (when `resolved_outcome` is present), or enrich outcome fields before sync. The sync script calls `resolve_market()` and writes Brier scores idempotently.
 
-## 6) GitHub Actions (recommended)
+## 6) Known limitations
+- Current psychohistory harness runner path is binary-first (`final_p_yes` scalar).
+- Summer/FutureEval includes numeric, discrete, and multiple-choice question types.
+- For launch, run binary-capable flows first (e.g., bot testing area / MiniBench subsets), then extend posting adapters for non-binary output shapes.
+
+## 7) GitHub Actions (recommended)
 - Fork this repo to your account.
 - Add secrets in GitHub Actions settings:
   - `METACULUS_TOKEN`

--- a/main.py
+++ b/main.py
@@ -1,7 +1,9 @@
 import argparse
 import asyncio
 import logging
+import os
 from datetime import datetime, timezone
+from pathlib import Path
 import dotenv
 from typing import Literal
 
@@ -30,6 +32,8 @@ from forecasting_tools import (
     clean_indents,
     structure_output,
 )
+
+from scripts.export_template_runs import export_from_forecast_report
 
 dotenv.load_dotenv()
 logger = logging.getLogger(__name__)
@@ -725,4 +729,15 @@ if __name__ == "__main__":
         forecast_reports = asyncio.run(
             template_bot.forecast_questions(questions, return_exceptions=True)
         )
+    output_dir = os.environ.get("PSYCHOHISTORY_OUTPUT_DIR", "").strip()
+    if output_dir:
+        out_path = Path(output_dir)
+        exported = 0
+        for report in forecast_reports:
+            if isinstance(report, Exception):
+                continue
+            if export_from_forecast_report(report, out_path) is not None:
+                exported += 1
+        logger.info("Exported %s forecast rows to %s", exported, out_path)
+
     template_bot.log_report_summary(forecast_reports)

--- a/scripts/export_template_runs.py
+++ b/scripts/export_template_runs.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _daily_path(output_dir: Path, when: datetime | None = None) -> Path:
+    now = when or datetime.now(timezone.utc)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return output_dir / f"runs-{now.date().isoformat()}.jsonl"
+
+
+def export_run(
+    question_id: int,
+    question_text: str,
+    p_yes: float,
+    reasoning: str,
+    close_date: str,
+    resolution_date: str,
+    outcome: bool | None,
+    output_dir: Path,
+) -> Path:
+    """Append one run record to output_dir/runs-YYYY-MM-DD.jsonl."""
+    if not (0.0 <= float(p_yes) <= 1.0):
+        raise ValueError("p_yes must be in [0,1]")
+
+    row = {
+        "question_id": int(question_id),
+        "question_text": question_text,
+        "run_timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "posted_probability": float(p_yes),
+        "close_date": close_date,
+        "resolution_date": resolution_date,
+        "resolved_outcome": outcome,
+        "reasoning": reasoning,
+    }
+
+    path = _daily_path(output_dir)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(row))
+        handle.write("\n")
+    return path
+
+
+def _first_number(value) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, list) and value and isinstance(value[0], (int, float)):
+        return float(value[0])
+    return None
+
+
+def export_from_forecast_report(report, output_dir: Path) -> Path | None:
+    """Best-effort extraction from forecasting-tools ForecastReport objects."""
+    question = getattr(report, "question", None)
+    if question is None:
+        return None
+
+    question_id = getattr(question, "id_of_post", None) or getattr(question, "id", None)
+    question_text = getattr(question, "question_text", None) or getattr(question, "title", "")
+    close_dt = getattr(question, "close_time", None) or getattr(question, "scheduled_close_time", None)
+    resolve_dt = getattr(question, "scheduled_resolve_time", None) or getattr(question, "resolve_time", None) or close_dt
+
+    if question_id is None or not question_text or close_dt is None or resolve_dt is None:
+        return None
+
+    prediction = getattr(report, "prediction", None)
+    p_yes = _first_number(prediction)
+    if p_yes is None:
+        prediction_obj = getattr(report, "prediction_value", None)
+        p_yes = _first_number(prediction_obj)
+    if p_yes is None:
+        return None
+
+    reasoning = getattr(report, "explanation", "") or getattr(report, "report", "") or ""
+
+    close_date = close_dt.date().isoformat() if hasattr(close_dt, "date") else str(close_dt)
+    resolution_date = resolve_dt.date().isoformat() if hasattr(resolve_dt, "date") else str(resolve_dt)
+
+    return export_run(
+        question_id=int(question_id),
+        question_text=str(question_text),
+        p_yes=float(p_yes),
+        reasoning=str(reasoning),
+        close_date=close_date,
+        resolution_date=resolution_date,
+        outcome=None,
+        output_dir=output_dir,
+    )

--- a/tests/test_export_template_runs.py
+++ b/tests/test_export_template_runs.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.export_template_runs import export_from_forecast_report, export_run
+
+
+class _Q:
+    def __init__(self) -> None:
+        self.id = 123
+        self.question_text = "Will X happen?"
+        self.close_time = "2026-06-01"
+        self.scheduled_resolve_time = "2026-07-01"
+
+
+class _Report:
+    def __init__(self) -> None:
+        self.question = _Q()
+        self.prediction = 0.64
+        self.explanation = "reasoning"
+
+
+def test_export_run_appends_daily_jsonl(tmp_path: Path) -> None:
+    path = export_run(
+        question_id=1,
+        question_text="Q",
+        p_yes=0.5,
+        reasoning="R",
+        close_date="2026-06-01",
+        resolution_date="2026-07-01",
+        outcome=None,
+        output_dir=tmp_path,
+    )
+    assert path.name.startswith("runs-")
+    rows = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+    assert len(rows) == 1
+    assert rows[0]["question_id"] == 1
+    assert rows[0]["posted_probability"] == 0.5
+
+
+def test_export_from_forecast_report_writes_expected_fields(tmp_path: Path) -> None:
+    out = export_from_forecast_report(_Report(), tmp_path)
+    assert out is not None
+    rows = [json.loads(line) for line in out.read_text().splitlines() if line.strip()]
+    assert rows[0]["question_id"] == 123
+    assert rows[0]["question_text"] == "Will X happen?"
+    assert rows[0]["posted_probability"] == 0.64


### PR DESCRIPTION
- Add PSYCHOHISTORY_OUTPUT_DIR env var hook to main.py (no-op if unset)
- Add scripts/export_template_runs.py: writes runs-YYYY-MM-DD.jsonl per forecast
  - Schema aligned with psychohistory sync v0 contract
  - export_from_forecast_report() adapter for template report objects
- Update .env.template with PSYCHOHISTORY_OUTPUT_DIR documentation
- Add docs/psychohistory-bootstrap.md: full end-to-end setup and run flow
- Add README integration snippet and exporter tests
- Add known limitation note: current harness path is binary-first; non-binary Summer question types tracked for follow-up

Tests: tests/test_export_template_runs.py
Breaking changes: none — existing template behaviour unchanged when env var not set
