### PR TITLE
Add bot review integration (opt-in)

### DIFF
--- a/.claude/skills/review-bot/SKILL.md
+++ b/.claude/skills/review-bot/SKILL.md
@@ -12,7 +12,7 @@ is read-only Metaculus API traffic. No forecasting, no publishing, no API spend.
 
 - **Never run the bot.** `python main.py` spends money and publishes comments. This skill
   only reads.
-- **Never read a whole report.** Pull one section of one question with `--show`.
+- **Never read a whole report.** Pull one section of one question with `show`.
 - **Ask before changing code.** Diagnose first, propose fixes in the review.
 - Metaculus rate-limits at roughly 5 requests/second and the client does not retry. A 429
   means rerun the command.
@@ -20,7 +20,7 @@ is read-only Metaculus API traffic. No forecasting, no publishing, no API spend.
 ## 1. Build the data
 
 ```bash
-python -m forecasting_tools.bot_review.cli --tournament <slug-or-id> \
+python -m forecasting_tools.bot_review.cli review --tournament <slug-or-id> \
     --output review.json --summary review-summary.md
 ```
 
@@ -68,7 +68,7 @@ spread that landed badly points at aggregation; one model alone and right is wor
 it rather than reading:
 
 ```bash
-python -m forecasting_tools.bot_review.cli --show <POST_ID> --comment <COMMENT_ID> \
+python -m forecasting_tools.bot_review.cli show <POST_ID> --comment <COMMENT_ID> \
     --section research | grep -niE "<the deciding fact>" | head
 ```
 
@@ -77,7 +77,7 @@ Found → the research had it and the forecasters underused it. Absent → likel
 **c. One or two rationales** — the outlier, or one from the cluster if they all agreed.
 
 ```bash
-python -m forecasting_tools.bot_review.cli --show <POST_ID> --comment <COMMENT_ID> --forecaster R1:F3
+python -m forecasting_tools.bot_review.cli show <POST_ID> --comment <COMMENT_ID> --forecaster R1:F3
 ```
 
 **d. The whole research section** — last resort, when the searches came up empty and you need

--- a/.claude/skills/review-bot/SKILL.md
+++ b/.claude/skills/review-bot/SKILL.md
@@ -87,8 +87,8 @@ reads to ration.
 Take `<COMMENT_ID>` from the question's `trace.comment_id`: on a question forecast more than
 once it names the run that was standing when the question was scored, which is the run whose
 reasoning affected the score. Without it you get the latest run. Forecaster keys
-(`R<report>:F<forecaster>`) and their predictions are in `trace.forecasters`; `model` is null
-unless the bot annotates its own summary bullets.
+(`R<report>:F<forecaster>`) and their predictions are in `trace.forecasters`; a key identifies
+a forecaster across questions, so it is what to use when naming a repeat outlier.
 
 Also worth asking: did the final prediction match where the reasoning pointed, and did the bot
 answer the question the resolution criteria actually asked?

--- a/.claude/skills/review-bot/SKILL.md
+++ b/.claude/skills/review-bot/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: review-bot
+description: Review how this forecasting bot actually performed on resolved Metaculus questions — build the outcome table, read the reports it posted, work out why the worst questions went wrong, and write a review. Use when asked to review bot performance, analyse scores, or work out why a forecast went wrong.
+---
+
+# Review this bot's forecasts
+
+Diagnose *why* the bot scored the way it did on questions that have resolved. Everything here
+is read-only Metaculus API traffic. No forecasting, no publishing, no API spend.
+
+## Hard rules
+
+- **Never run the bot.** `python main.py` spends money and publishes comments. This skill
+  only reads.
+- **Never read a whole report.** Pull one section of one question with `--show`.
+- **Ask before changing code.** Diagnose first, propose fixes in the review.
+- Metaculus rate-limits at roughly 5 requests/second and the client does not retry. A 429
+  means rerun the command.
+
+## 1. Build the data
+
+```bash
+python -m forecasting_tools.bot_review.cli --tournament <slug-or-id> \
+    --output review.json --summary review-summary.md
+```
+
+Also `--post <POST_ID> ...` for specific questions, `--resolved-since <DAYS>` for anything
+that resolved recently, `--from-json review.json` to re-render without refetching. Roughly one
+request per post.
+
+Read the summary first, then `review.json` for per-question detail.
+
+## 2. Pick questions to investigate
+
+Around ten, fewer once findings repeat. Most of the budget goes on the worst scores. Also:
+
+- **Forecasted but unscored while resolved** — annulled, or something odder.
+- **`traces` non-empty but `trace` null** — every run came after `spot_scoring_time`, so the
+  forecast was never counted.
+- **Fewer forecasters than the bot's usual** — compare `len(trace.forecasters)` across the
+  table.
+- **`trace.truncated` true** — the comment hit Metaculus's size cap and only its opening
+  survives. Report it as a lost trace; there is nothing to diagnose.
+- **No trace at all** — the bot never forecast, or never published a comment.
+
+Those four are mechanical: no reading needed. When one of them matches many questions, that is
+a single finding with a count, not a dozen questions to read.
+
+Rank on whichever score the leaderboard uses — the summary names it. Peer scores are relative
+to other forecasters, so negative means you did worse than the field, and the tournament score
+is the sum.
+
+Well-scored questions are not routine reading; they rarely produce a fix. Read one only to
+test a hypothesis the losses raised, and only after checking whether the table can test it for
+free — a claimed bias is usually answerable by comparing forecasts to resolutions across every
+question. A list of losses looks like a systematic bias whether or not one exists, so test the
+patterns you think you see.
+
+## 3. Read the report, cheapest first
+
+Stop as soon as the question is answered.
+
+**a. The trace** — free, already in `review.json`. Every forecaster's prediction, the count,
+the run time. A tight cluster that all missed points at a shared input or blind spot; a wide
+spread that landed badly points at aggregation; one model alone and right is worth naming.
+
+**b. Search the research** — near-free. You know what the question resolved to, so search for
+it rather than reading:
+
+```bash
+python -m forecasting_tools.bot_review.cli --show <POST_ID> --comment <COMMENT_ID> \
+    --section research | grep -niE "<the deciding fact>" | head
+```
+
+Found → the research had it and the forecasters underused it. Absent → likely a research gap.
+
+**c. One or two rationales** — the outlier, or one from the cluster if they all agreed.
+
+```bash
+python -m forecasting_tools.bot_review.cli --show <POST_ID> --comment <COMMENT_ID> --forecaster R1:F3
+```
+
+**d. The whole research section** — last resort, when the searches came up empty and you need
+to know what the bot actually had. A research section dwarfs a rationale, so these are the
+reads to ration.
+
+Take `<COMMENT_ID>` from the question's `trace.comment_id`: on a question forecast more than
+once it names the run that was standing when the question was scored, which is the run whose
+reasoning affected the score. Without it you get the latest run. Forecaster keys
+(`R<report>:F<forecaster>`) and their predictions are in `trace.forecasters`; `model` is null
+unless the bot annotates its own summary bullets.
+
+Also worth asking: did the final prediction match where the reasoning pointed, and did the bot
+answer the question the resolution criteria actually asked?
+
+## 4. Write the review
+
+Write `review.md`:
+
+- **Summary** — score, rank, and the two or three things that actually moved it.
+- **Per question** — title and link, score, and what went wrong in your own words, with the
+  quote or absence from the report that shows it. One or two sentences each.
+- **Patterns** — causes that recur, and any model repeatedly out on its own.
+- **Suggestions** — concrete: a prompt change, a research gap, a scheduling fix. Name the
+  questions each would have helped and drop anything you cannot tie to one.
+
+"Well forecast, unlucky outcome" is a real finding. Do not manufacture a process failure for a
+question the bot handled well. State plainly where the evidence is thin — three well-supported
+findings beat ten guesses.

--- a/.claude/skills/review-bot/SKILL.md
+++ b/.claude/skills/review-bot/SKILL.md
@@ -19,8 +19,11 @@ is read-only Metaculus API traffic. No forecasting, no publishing, no API spend.
 
 ## 1. Build the data
 
+`bot-review` comes from the optional `metaculus-bot-review` package. If it is not installed,
+run `poetry install --with integrations` first.
+
 ```bash
-python -m forecasting_tools.bot_review.cli review --tournament <slug-or-id> \
+poetry run bot-review review --tournament <slug-or-id> \
     --output review.json --summary review-summary.md
 ```
 
@@ -68,7 +71,7 @@ spread that landed badly points at aggregation; one model alone and right is wor
 it rather than reading:
 
 ```bash
-python -m forecasting_tools.bot_review.cli show <POST_ID> --comment <COMMENT_ID> \
+poetry run bot-review show <POST_ID> --comment <COMMENT_ID> \
     --section research | grep -niE "<the deciding fact>" | head
 ```
 
@@ -77,7 +80,7 @@ Found → the research had it and the forecasters underused it. Absent → likel
 **c. One or two rationales** — the outlier, or one from the cluster if they all agreed.
 
 ```bash
-python -m forecasting_tools.bot_review.cli show <POST_ID> --comment <COMMENT_ID> --forecaster R1:F3
+poetry run bot-review show <POST_ID> --comment <COMMENT_ID> --forecaster R1:F3
 ```
 
 **d. The whole research section** — last resort, when the searches came up empty and you need

--- a/.github/workflows/review_bot.yaml
+++ b/.github/workflows/review_bot.yaml
@@ -16,10 +16,11 @@ concurrency:
 
 # Scores how the bot's resolved forecasts turned out. Read-only: it makes no
 # forecasts, spends nothing on LLMs, and publishes nothing.
-# Set the repository variable REVIEW_BOT_ENABLED to false to turn it off.
+# The weekly run is off by default: set the repository variable REVIEW_BOT_ENABLED to
+# true to turn it on. Running it by hand always works.
 jobs:
   review_job:
-    if: vars.REVIEW_BOT_ENABLED != 'false'
+    if: vars.REVIEW_BOT_ENABLED == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/.github/workflows/review_bot.yaml
+++ b/.github/workflows/review_bot.yaml
@@ -37,7 +37,7 @@ jobs:
         run: poetry install --no-interaction --no-root
       - name: Review forecasts
         run: |
-          poetry run bot-review \
+          poetry run bot-review review \
             --resolved-since ${{ inputs.days || 30 }} \
             --output review.json \
             --summary review.md

--- a/.github/workflows/review_bot.yaml
+++ b/.github/workflows/review_bot.yaml
@@ -34,7 +34,7 @@ jobs:
           virtualenvs-in-project: true
           installer-parallel: true
       - name: Install dependencies
-        run: poetry install --no-interaction --no-root
+        run: poetry install --no-interaction --no-root --with integrations
       - name: Review forecasts
         run: |
           poetry run bot-review review \

--- a/.github/workflows/review_bot.yaml
+++ b/.github/workflows/review_bot.yaml
@@ -1,0 +1,55 @@
+name: Review recent forecasts
+
+on:
+  workflow_dispatch:
+    inputs:
+      days:
+        description: "How many days back to look for resolved questions"
+        default: "30"
+  schedule:
+    - cron: "0 6 * * 1" # weekly, Monday morning
+
+# Add concurrency group to prevent parallel runs
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+# Scores how the bot's resolved forecasts turned out. Read-only: it makes no
+# forecasts, spends nothing on LLMs, and publishes nothing.
+# Set the repository variable REVIEW_BOT_ENABLED to false to turn it off.
+jobs:
+  review_job:
+    if: vars.REVIEW_BOT_ENABLED != 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+      - name: Install dependencies
+        run: poetry install --no-interaction --no-root
+      - name: Review forecasts
+        run: |
+          poetry run bot-review \
+            --resolved-since ${{ inputs.days || 30 }} \
+            --output review.json \
+            --summary review.md
+        env:
+          METACULUS_TOKEN: ${{ secrets.METACULUS_TOKEN }}
+      - name: Show the summary in the run page
+        run: cat review.md >> $GITHUB_STEP_SUMMARY
+      - name: Keep the review
+        uses: actions/upload-artifact@v4
+        with:
+          name: review
+          path: |
+            review.json
+            review.md
+          retention-days: 90

--- a/README.md
+++ b/README.md
@@ -120,6 +120,27 @@ To stop publishing forecasts (dry-run mode):
 - `main.py`: set `publish_reports_to_metaculus=False` in the `SummerTemplateBot2026(...)` constructor near the bottom.
 - `main_with_no_framework.py`: set `SUBMIT_PREDICTION = False` at the top.
 
+## Reviewing how your bot did
+
+Once your questions start resolving, `bot-review` scores them and shows you what the bot was
+thinking on the ones it got wrong. It only reads: no forecasting, no LLM spend, nothing
+published.
+
+```bash
+poetry run bot-review --tournament <slug-or-id> --output review.json --summary review.md
+poetry run bot-review --resolved-since 30          # anything that resolved recently
+```
+
+You get your rank and score, which questions cost the most, and every forecaster's prediction
+per question. `--show <POST_ID> --section research` pulls one part of a report back out.
+
+The **Review recent forecasts** workflow runs this weekly and attaches the result to the run.
+It needs only `METACULUS_TOKEN`. To turn it off, set the repository variable
+`REVIEW_BOT_ENABLED` to `false` (Settings → Secrets and variables → Actions → Variables).
+
+If you use Claude Code, the `review-bot` skill in `.claude/skills/` drives all of this and
+writes up what it finds — ask it to "review how the bot did on \<tournament\>".
+
 ## Example usage of /news and /deepnews:
 If you are using AskNews, here is some useful example code.
 ```python

--- a/README.md
+++ b/README.md
@@ -122,25 +122,18 @@ To stop publishing forecasts (dry-run mode):
 
 ## Reviewing how your bot did
 
-Once your questions start resolving, `bot-review` scores them and shows you what the bot was
-thinking on the ones it got wrong. It only reads: no forecasting, no LLM spend, nothing
-published.
+Once your questions start resolving, the optional
+[bot-review](https://github.com/LouisP96/metaculus-bot-review) integration scores them and
+shows you what the bot was thinking on the ones it got wrong. It only reads: no forecasting,
+no LLM spend, nothing published.
 
 ```bash
-poetry run bot-review review --tournament <slug-or-id> --output review.json --summary review.md
-poetry run bot-review review --resolved-since 30    # anything that resolved recently
+poetry install --with integrations
+poetry run bot-review review --resolved-since 30
 ```
 
-You get your rank and score, which questions cost the most, and every forecaster's prediction
-per question. `bot-review show <POST_ID> --section research` pulls one part of a report back
-out.
-
-The **Review recent forecasts** workflow runs this weekly and attaches the result to the run.
-It needs only `METACULUS_TOKEN`. To turn it off, set the repository variable
-`REVIEW_BOT_ENABLED` to `false` (Settings → Secrets and variables → Actions → Variables).
-
-If you use Claude Code, the `review-bot` skill in `.claude/skills/` drives all of this and
-writes up what it finds — ask it to "review how the bot did on \<tournament\>".
+A weekly workflow and a Claude Code skill come with it. See the
+[integrations README](integrations/README.md#bot-review).
 
 ## Example usage of /news and /deepnews:
 If you are using AskNews, here is some useful example code.

--- a/README.md
+++ b/README.md
@@ -127,12 +127,13 @@ thinking on the ones it got wrong. It only reads: no forecasting, no LLM spend, 
 published.
 
 ```bash
-poetry run bot-review --tournament <slug-or-id> --output review.json --summary review.md
-poetry run bot-review --resolved-since 30          # anything that resolved recently
+poetry run bot-review review --tournament <slug-or-id> --output review.json --summary review.md
+poetry run bot-review review --resolved-since 30    # anything that resolved recently
 ```
 
 You get your rank and score, which questions cost the most, and every forecaster's prediction
-per question. `--show <POST_ID> --section research` pulls one part of a report back out.
+per question. `bot-review show <POST_ID> --section research` pulls one part of a report back
+out.
 
 The **Review recent forecasts** workflow runs this weekly and attaches the result to the run.
 It needs only `METACULUS_TOKEN`. To turn it off, set the repository variable

--- a/README.md
+++ b/README.md
@@ -124,8 +124,7 @@ To stop publishing forecasts (dry-run mode):
 
 Once your questions start resolving, the optional
 [bot-review](https://github.com/LouisP96/metaculus-bot-review) integration scores them and
-shows you what the bot was thinking on the ones it got wrong. It only reads: no forecasting,
-no LLM spend, nothing published.
+helps to diagnose any reasoning errors.
 
 ```bash
 poetry install --with integrations

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ To stop publishing forecasts (dry-run mode):
 
 ## Reviewing how your bot did
 
-Once your questions start resolving, the optional
+Once your questions start resolving, the community-member-maintained optional
 [bot-review](https://github.com/LouisP96/metaculus-bot-review) integration scores them and
 helps to diagnose any reasoning errors.
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -55,7 +55,7 @@ poetry run bot-review show <POST_ID> --forecaster R1:F3
 
 Two extras ship with this template:
 
-- **[.github/workflows/review_bot.yaml](../.github/workflows/review_bot.yaml)** runs the review weekly and attaches `review.json` and `review.md` to the run. It needs only `METACULUS_TOKEN`. Set the repository variable `REVIEW_BOT_ENABLED` to `false` to turn it off.
+- **[.github/workflows/review_bot.yaml](../.github/workflows/review_bot.yaml)** runs the review weekly and attaches `review.json` and `review.md` to the run. It needs only `METACULUS_TOKEN`. It is off by default: set the repository variable `REVIEW_BOT_ENABLED` to `true` to turn it on (Settings → Secrets and variables → Actions → Variables).
 - **[.claude/skills/review-bot/SKILL.md](../.claude/skills/review-bot/SKILL.md)** drives the whole loop with Claude Code and writes up what it finds. Ask it to review how the bot did on a tournament.
 
 ## Add your own

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -32,6 +32,32 @@ Create an account at [lightningrod.ai](https://lightningrod.ai/) and explore the
 poetry run python integrations/main_lightningrod_eval.py
 ```
 
+### Bot Review
+
+**[metaculus-bot-review](https://github.com/LouisP96/metaculus-bot-review)** - Scores your bot's resolved forecasts and shows you what it was thinking on the ones it got wrong.
+
+It reads the reports your bot published as Metaculus comments, so there is nothing to set up beyond the `METACULUS_TOKEN` you already have. It only reads: no forecasting, no LLM spend, nothing published.
+
+```bash
+poetry install --with integrations
+poetry run bot-review review --tournament <slug-or-id> --output review.json --summary review.md
+poetry run bot-review review --resolved-since 30    # anything that resolved recently
+```
+
+`review.md` gives your rank, how many questions were scored, and the best and worst questions on whichever score the leaderboard uses. `review.json` adds per-question detail, including every forecaster's prediction on every run.
+
+Reasoning text is not in the table. Pull it a piece at a time:
+
+```bash
+poetry run bot-review show <POST_ID> --section research
+poetry run bot-review show <POST_ID> --forecaster R1:F3
+```
+
+Two extras ship with this template:
+
+- **[.github/workflows/review_bot.yaml](../.github/workflows/review_bot.yaml)** runs the review weekly and attaches `review.json` and `review.md` to the run. It needs only `METACULUS_TOKEN`. Set the repository variable `REVIEW_BOT_ENABLED` to `false` to turn it off.
+- **[.claude/skills/review-bot/SKILL.md](../.claude/skills/review-bot/SKILL.md)** drives the whole loop with Claude Code and writes up what it finds. Ask it to review how the bot did on a tournament.
+
 ## Add your own
 
 Have a tool or SDK that could help with forecasting? Add it here and open a PR!

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -34,9 +34,9 @@ poetry run python integrations/main_lightningrod_eval.py
 
 ### Bot Review
 
-**[metaculus-bot-review](https://github.com/LouisP96/metaculus-bot-review)** - Scores your bot's resolved forecasts and shows you what it was thinking on the ones it got wrong.
+**[metaculus-bot-review](https://github.com/LouisP96/metaculus-bot-review)** - Scores your bot's resolved forecasts and displays its reasoning on specific questions.
 
-It reads the reports your bot published as Metaculus comments, so there is nothing to set up beyond the `METACULUS_TOKEN` you already have. It only reads: no forecasting, no LLM spend, nothing published.
+It reads the reports your bot published as Metaculus comments, so there is nothing to set up beyond the `METACULUS_TOKEN` you already have. No LLM spend is incurred.
 
 ```bash
 poetry install --with integrations

--- a/poetry.lock
+++ b/poetry.lock
@@ -6,7 +6,7 @@ version = "25.1.0"
 description = "File support for asyncio."
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695"},
     {file = "aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2"},
@@ -18,7 +18,7 @@ version = "2.6.1"
 description = "Happy Eyeballs for asyncio"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8"},
     {file = "aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558"},
@@ -30,7 +30,7 @@ version = "3.13.2"
 description = "Async http client/server framework (asyncio)"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "aiohttp-3.13.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2372b15a5f62ed37789a6b383ff7344fc5b9f243999b0cd9b629d8bc5f5b4155"},
     {file = "aiohttp-3.13.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e7f8659a48995edee7229522984bd1009c1213929c769c2daa80b40fe49a180c"},
@@ -172,7 +172,7 @@ version = "1.2.1"
 description = "asyncio rate limiter, a leaky bucket implementation"
 optional = false
 python-versions = "<4.0,>=3.8"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "aiolimiter-1.2.1-py3-none-any.whl", hash = "sha256:d3f249e9059a20badcb56b61601a83556133655c11d1eb3dd3e04ff069e5f3c7"},
     {file = "aiolimiter-1.2.1.tar.gz", hash = "sha256:e02a37ea1a855d9e832252a105420ad4d15011505512a1a1d814647451b5cca9"},
@@ -184,7 +184,7 @@ version = "1.4.0"
 description = "aiosignal: a list of registered asynchronous callbacks"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e"},
     {file = "aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7"},
@@ -200,7 +200,7 @@ version = "6.0.0"
 description = "Vega-Altair: A declarative statistical visualization library for Python."
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "altair-6.0.0-py3-none-any.whl", hash = "sha256:09ae95b53d5fe5b16987dccc785a7af8588f2dca50de1e7a156efa8a461515f8"},
     {file = "altair-6.0.0.tar.gz", hash = "sha256:614bf5ecbe2337347b590afb111929aa9c16c9527c4887d96c9bc7f6640756b4"},
@@ -269,7 +269,7 @@ version = "3.11.0"
 description = "ASGI specs, helper code, and adapters"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "asgiref-3.11.0-py3-none-any.whl", hash = "sha256:1db9021efadb0d9512ce8ffaf72fcef601c7b73a8807a1bb2ef143dc6b14846d"},
     {file = "asgiref-3.11.0.tar.gz", hash = "sha256:13acff32519542a1736223fb79a715acdebe24286d98e8b164a73085f40da2c4"},
@@ -284,7 +284,7 @@ version = "0.13.45"
 description = "Python SDK for AskNews"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "asknews-0.13.45-py3-none-any.whl", hash = "sha256:60d3dbff1f2ddef44906e8f210c231760b84463019c3c7ffd29d8c4dd107c440"},
 ]
@@ -319,7 +319,7 @@ version = "4.0.0"
 description = "Deprecated backport of asyncio; use the stdlib package instead"
 optional = false
 python-versions = ">=3.4"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "asyncio-4.0.0-py3-none-any.whl", hash = "sha256:c1eddb0659231837046809e68103969b2bef8b0400d59cfa6363f6b5ed8cc88b"},
     {file = "asyncio-4.0.0.tar.gz", hash = "sha256:570cd9e50db83bc1629152d4d0b7558d6451bb1bfd5dfc2e935d96fc2f40329b"},
@@ -343,7 +343,7 @@ version = "1.9.0"
 description = "Fast, simple object-to-object and broadcast signaling"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc"},
     {file = "blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf"},
@@ -355,7 +355,7 @@ version = "6.2.4"
 description = "Extensible memoizing collections and decorators"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "cachetools-6.2.4-py3-none-any.whl", hash = "sha256:69a7a52634fed8b8bf6e24a050fb60bff1c9bd8f6d24572b99c32d4e71e62a51"},
     {file = "cachetools-6.2.4.tar.gz", hash = "sha256:82c5c05585e70b6ba2d3ae09ea60b79548872185d2f24ae1f2709d37299fd607"},
@@ -379,7 +379,7 @@ version = "2.0.0"
 description = "Foreign Function Interface for Python calling C code."
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main", "dev", "integrations"]
 files = [
     {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
     {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
@@ -466,7 +466,7 @@ files = [
     {file = "cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9"},
     {file = "cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"},
 ]
-markers = {main = "platform_python_implementation != \"PyPy\"", dev = "implementation_name == \"pypy\""}
+markers = {main = "platform_python_implementation != \"PyPy\"", dev = "implementation_name == \"pypy\"", integrations = "platform_python_implementation != \"PyPy\""}
 
 [package.dependencies]
 pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
@@ -600,7 +600,7 @@ version = "8.3.1"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6"},
     {file = "click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a"},
@@ -615,7 +615,7 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["main", "dev"]
+groups = ["main", "dev", "integrations"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -643,7 +643,7 @@ version = "1.0.5"
 description = "Parse and use crontab schedules in Python"
 optional = false
 python-versions = "*"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "crontab-1.0.5.tar.gz", hash = "sha256:f80e01b4f07219763a9869f926dd17147278e7965a928089bca6d3dc80ae46d5"},
 ]
@@ -654,7 +654,7 @@ version = "45.0.4"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.7"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "cryptography-45.0.4-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:425a9a6ac2823ee6e46a76a21a4e8342d8fa5c01e08b823c1f19a8b74f096069"},
     {file = "cryptography-45.0.4-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:680806cf63baa0039b920f4976f5f31b10e772de42f16310a6839d9f21a26b0d"},
@@ -766,7 +766,7 @@ version = "1.9.0"
 description = "Distro - an OS platform information API"
 optional = false
 python-versions = ">=3.6"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2"},
     {file = "distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed"},
@@ -778,7 +778,7 @@ version = "2.8.0"
 description = "DNS toolkit"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af"},
     {file = "dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f"},
@@ -799,7 +799,7 @@ version = "2.3.0"
 description = "A robust email address syntax and deliverability validation library."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4"},
     {file = "email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426"},
@@ -815,7 +815,7 @@ version = "1.3.1"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598"},
     {file = "exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219"},
@@ -848,7 +848,7 @@ version = "38.2.0"
 description = "Faker is a Python package that generates fake data for you."
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "faker-38.2.0-py3-none-any.whl", hash = "sha256:35fe4a0a79dee0dc4103a6083ee9224941e7d3594811a50e3969e547b0d2ee65"},
     {file = "faker-38.2.0.tar.gz", hash = "sha256:20672803db9c7cb97f9b56c18c54b915b6f1d8991f63d1d673642dc43f5ce7ab"},
@@ -863,7 +863,7 @@ version = "0.14.0"
 description = "Python bindings to Rust's UUID library."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "fastuuid-0.14.0-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:6e6243d40f6c793c3e2ee14c13769e341b90be5ef0c23c82fa6515a96145181a"},
     {file = "fastuuid-0.14.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:13ec4f2c3b04271f62be2e1ce7e95ad2dd1cf97e94503a3760db739afbd48f00"},
@@ -951,7 +951,7 @@ version = "3.20.1"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "filelock-3.20.1-py3-none-any.whl", hash = "sha256:15d9e9a67306188a44baa72f569d2bfd803076269365fdea0934385da4dc361a"},
     {file = "filelock-3.20.1.tar.gz", hash = "sha256:b8360948b351b80f420878d8516519a2204b07aefcdcfd24912a5d33127f188c"},
@@ -959,14 +959,14 @@ files = [
 
 [[package]]
 name = "forecasting-tools"
-version = "0.2.90"
+version = "0.2.92"
 description = "AI forecasting and research tools to help humans reason about and forecast the future"
 optional = false
 python-versions = "<4.0,>=3.11"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
-    {file = "forecasting_tools-0.2.90-py3-none-any.whl", hash = "sha256:e50f7d5cc72caf87b9783062bb9824d4b87e680e64cb379383df44c8b008d5a0"},
-    {file = "forecasting_tools-0.2.90.tar.gz", hash = "sha256:e83738145c74619f930f8dd5fcf3ab16287cb42596730225d6a54947b85731de"},
+    {file = "forecasting_tools-0.2.92-py3-none-any.whl", hash = "sha256:7d45ba22bd7406f0af55a854f6bfb05c81b042011530ad7557a40f52673e3c13"},
+    {file = "forecasting_tools-0.2.92.tar.gz", hash = "sha256:a1e4942fa53d22c69a7b1e015761df1d2e8712832fa6ffd99c645fa9c181e886"},
 ]
 
 [package.dependencies]
@@ -982,7 +982,7 @@ litellm = ">=1.59.1,<1.76.dev0 || >=1.78.dev0,<1.82.7 || >1.82.7,<1.82.8 || >1.8
 nest-asyncio = ">=1.5.8,<2.0.0"
 numpy = ">=1.26.0,<3.0.0"
 openai = ">=1.51.0,<3.0.0"
-openai-agents = {version = ">=0.2.0,<0.14.0", extras = ["litellm"]}
+openai-agents = {version = ">=0.2.0,<0.20.0", extras = ["litellm"]}
 pandas = ">=2.2.3,<4.0.0"
 pendulum = ">=3.1.0,<4.0.0"
 pillow = ">=9.0.0,<13.0.0"
@@ -994,7 +994,7 @@ requests = ">=2.32.3,<3.0.0"
 scikit-learn = ">=1.5.2,<2.0.0"
 streamlit = ">=1.20.0,<2.0.0"
 tenacity = ">=8.0.0,<10.0.0"
-tiktoken = ">=0.8.0,<0.13.0"
+tiktoken = ">=0.8.0,<0.20.0"
 typeguard = ">=4.3.0,<5.0.0"
 unidecode = ">=1.4.0,<2.0.0"
 
@@ -1004,7 +1004,7 @@ version = "1.8.0"
 description = "A list-like structure which implements collections.abc.MutableSequence"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "frozenlist-1.8.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b37f6d31b3dcea7deb5e9696e529a6aa4a898adc33db82da12e4c60a7c4d2011"},
     {file = "frozenlist-1.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ef2b7b394f208233e471abc541cc6991f907ffd47dc72584acee3147899d6565"},
@@ -1184,7 +1184,7 @@ version = "4.0.12"
 description = "Git Object Database"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf"},
     {file = "gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571"},
@@ -1199,7 +1199,7 @@ version = "3.1.45"
 description = "GitPython is a Python library used to interact with Git repositories"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "gitpython-3.1.45-py3-none-any.whl", hash = "sha256:8908cb2e02fb3b93b7eb0f2827125cb699869470432cc885f019b8fd0fccff77"},
     {file = "gitpython-3.1.45.tar.gz", hash = "sha256:85b0ee964ceddf211c41b9f27a49086010a190fd8132a24e21f362a4b36a791c"},
@@ -1218,7 +1218,7 @@ version = "1.15.0"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "griffe-1.15.0-py3-none-any.whl", hash = "sha256:6f6762661949411031f5fcda9593f586e6ce8340f0ba88921a0f2ef7a81eb9a3"},
     {file = "griffe-1.15.0.tar.gz", hash = "sha256:7726e3afd6f298fbc3696e67958803e7ac843c1cfe59734b6251a40cdbfb5eea"},
@@ -1236,7 +1236,7 @@ version = "1.67.1"
 description = "HTTP/2-based RPC framework"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "integrations"]
 markers = "python_version < \"3.14\""
 files = [
     {file = "grpcio-1.67.1-cp310-cp310-linux_armv7l.whl", hash = "sha256:8b0341d66a57f8a3119b77ab32207072be60c9bf79760fa609c5609f2deb1f3f"},
@@ -1305,7 +1305,7 @@ version = "1.76.0"
 description = "HTTP/2-based RPC framework"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 markers = "python_version >= \"3.14\""
 files = [
     {file = "grpcio-1.76.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:65a20de41e85648e00305c1bb09a3598f840422e522277641145a32d42dcefcc"},
@@ -1395,7 +1395,7 @@ version = "1.2.0"
 description = "Fast transfer of large files with the Hugging Face Hub."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "integrations"]
 markers = "platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\""
 files = [
     {file = "hf_xet-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:ceeefcd1b7aed4956ae8499e2199607765fbd1c60510752003b6cc0b8413b649"},
@@ -1478,7 +1478,7 @@ version = "0.4.3"
 description = "Consume Server-Sent Event (SSE) messages with HTTPX."
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc"},
     {file = "httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d"},
@@ -1490,7 +1490,7 @@ version = "1.2.3"
 description = "Client library to download and publish models, datasets and other repos on the huggingface.co hub"
 optional = false
 python-versions = ">=3.9.0"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "huggingface_hub-1.2.3-py3-none-any.whl", hash = "sha256:c9b7a91a9eedaa2149cdc12bdd8f5a11780e10de1f1024718becf9e41e5a4642"},
     {file = "huggingface_hub-1.2.3.tar.gz", hash = "sha256:4ba57f17004fd27bb176a6b7107df579865d4cde015112db59184c51f5602ba7"},
@@ -1526,7 +1526,7 @@ version = "0.75.0"
 description = "Python SDK for hyperbrowser"
 optional = false
 python-versions = "<4.0,>=3.8"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "hyperbrowser-0.75.0-py3-none-any.whl", hash = "sha256:aa2d15f4a474d12c2064df877b36fa47e285bbc6ce9737f7d1fe2cd779541977"},
     {file = "hyperbrowser-0.75.0.tar.gz", hash = "sha256:102eb548e47242aa03188dc4747aaae0e4e778a9e5c69d1e17883e1823de97f4"},
@@ -1558,7 +1558,7 @@ version = "8.7.0"
 description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd"},
     {file = "importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000"},
@@ -1684,7 +1684,7 @@ version = "3.1.6"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
     {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
@@ -1702,7 +1702,7 @@ version = "0.12.0"
 description = "Fast iterable JSON parser."
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "jiter-0.12.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:e7acbaba9703d5de82a2c98ae6a0f59ab9770ab5af5fa35e43a303aee962cf65"},
     {file = "jiter-0.12.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:364f1a7294c91281260364222f535bc427f56d4de1d8ffd718162d21fbbd602e"},
@@ -1814,7 +1814,7 @@ version = "1.5.3"
 description = "Lightweight pipelining with Python functions"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713"},
     {file = "joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3"},
@@ -1826,7 +1826,7 @@ version = "1.1.0"
 description = "jsonref is a library for automatic dereferencing of JSON Reference objects for Python."
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9"},
     {file = "jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552"},
@@ -1838,7 +1838,7 @@ version = "4.25.1"
 description = "An implementation of JSON Schema validation for Python"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "jsonschema-4.25.1-py3-none-any.whl", hash = "sha256:3fba0169e345c7175110351d456342c364814cfcf3b964ba4587f22915230a63"},
     {file = "jsonschema-4.25.1.tar.gz", hash = "sha256:e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85"},
@@ -1860,7 +1860,7 @@ version = "2025.9.1"
 description = "The JSON Schema meta-schemas and vocabularies, exposed as a Registry"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe"},
     {file = "jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d"},
@@ -1944,7 +1944,7 @@ version = "1.80.10"
 description = "Library to easily interface with LLM API providers"
 optional = false
 python-versions = "<4.0,>=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "litellm-1.80.10-py3-none-any.whl", hash = "sha256:9b3e561efaba0eb1291cb1555d3dcb7283cf7f3cb65aadbcdb42e2a8765898c8"},
     {file = "litellm-1.80.10.tar.gz", hash = "sha256:4a4aff7558945c2f7e5c6523e67c1b5525a46b10b0e1ad6b8f847cb13b16779e"},
@@ -2006,7 +2006,7 @@ version = "3.0.3"
 description = "Safely add untrusted strings to HTML/XML markup."
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559"},
     {file = "markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419"},
@@ -2123,7 +2123,7 @@ version = "1.24.0"
 description = "Model Context Protocol SDK"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "mcp-1.24.0-py3-none-any.whl", hash = "sha256:db130e103cc50ddc3dffc928382f33ba3eaef0b711f7a87c05e7ded65b1ca062"},
     {file = "mcp-1.24.0.tar.gz", hash = "sha256:aeaad134664ce56f2721d1abf300666a1e8348563f4d3baff361c3b652448efc"},
@@ -2163,12 +2163,30 @@ files = [
 ]
 
 [[package]]
+name = "metaculus-bot-review"
+version = "0.1.1"
+description = "Review how a Metaculus forecasting bot performed on the questions it forecast"
+optional = false
+python-versions = "<4.0,>=3.11"
+groups = ["integrations"]
+files = [
+    {file = "metaculus_bot_review-0.1.1-py3-none-any.whl", hash = "sha256:72b7643a8be8d766cba0c084333277f09e8d5acbbcccc8f411aaacab4cb780dd"},
+    {file = "metaculus_bot_review-0.1.1.tar.gz", hash = "sha256:c7e7b0693bb3c4bf8eeb6f90ade9d8b3472258253aad870ff54aac921967f8ac"},
+]
+
+[package.dependencies]
+forecasting-tools = ">=0.2.92,<0.3.0"
+pydantic = ">=2.0,<3.0"
+python-dotenv = ">=1.0,<2.0"
+requests = ">=2.31,<3.0"
+
+[[package]]
 name = "multidict"
 version = "6.7.0"
 description = "multidict implementation"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "multidict-6.7.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9f474ad5acda359c8758c8accc22032c6abe6dc87a8be2440d097785e27a9349"},
     {file = "multidict-6.7.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4b7a9db5a870f780220e931d0002bbfd88fb53aceb6293251e2c839415c1b20e"},
@@ -2324,7 +2342,7 @@ version = "2.14.0"
 description = "Extremely lightweight compatibility layer between dataframe libraries"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "narwhals-2.14.0-py3-none-any.whl", hash = "sha256:b56796c9a00179bd757d15282c540024e1d5c910b19b8c9944d836566c030acf"},
     {file = "narwhals-2.14.0.tar.gz", hash = "sha256:98be155c3599db4d5c211e565c3190c398c87e7bf5b3cdb157dece67641946e0"},
@@ -2349,7 +2367,7 @@ version = "1.6.0"
 description = "Patch asyncio to allow nested event loops"
 optional = false
 python-versions = ">=3.5"
-groups = ["main", "dev"]
+groups = ["main", "dev", "integrations"]
 files = [
     {file = "nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c"},
     {file = "nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe"},
@@ -2361,7 +2379,7 @@ version = "2.3.5"
 description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.11"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "numpy-2.3.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:de5672f4a7b200c15a4127042170a694d4df43c992948f5e1af57f0174beed10"},
     {file = "numpy-2.3.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:acfd89508504a19ed06ef963ad544ec6664518c863436306153e13e94605c218"},
@@ -2445,7 +2463,7 @@ version = "2.13.0"
 description = "The official Python library for the openai API"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "openai-2.13.0-py3-none-any.whl", hash = "sha256:746521065fed68df2f9c2d85613bb50844343ea81f60009b60e6a600c9352c79"},
     {file = "openai-2.13.0.tar.gz", hash = "sha256:9ff633b07a19469ec476b1e2b5b26c5ef700886524a7a72f65e6f0b5203142d5"},
@@ -2473,7 +2491,7 @@ version = "0.6.3"
 description = "OpenAI Agents SDK"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "openai_agents-0.6.3-py3-none-any.whl", hash = "sha256:ada8b598f4db787939a62c8a291d07cbe68dae2d635955c44a0a0300746ee84f"},
     {file = "openai_agents-0.6.3.tar.gz", hash = "sha256:436479f201910cfc466893854b47d0f3acbf7b3bdafa95eedb590ed0d40393ef"},
@@ -2505,7 +2523,7 @@ version = "3.11.5"
 description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "orjson-3.11.5-cp310-cp310-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:df9eadb2a6386d5ea2bfd81309c505e125cfc9ba2b1b99a97e60985b0b3665d1"},
     {file = "orjson-3.11.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ccc70da619744467d8f1f49a8cadae5ec7bbe054e5232d95f92ed8737f8c5870"},
@@ -2602,7 +2620,7 @@ version = "25.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main", "dev", "integrations"]
 files = [
     {file = "packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"},
     {file = "packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"},
@@ -2614,7 +2632,7 @@ version = "2.3.3"
 description = "Powerful data structures for data analysis, time series, and statistics"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "pandas-2.3.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:376c6446ae31770764215a6c937f72d917f214b43560603cd60da6408f183b6c"},
     {file = "pandas-2.3.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e19d192383eab2f4ceb30b412b22ea30690c9e618f78870357ae1d682912015a"},
@@ -2729,7 +2747,7 @@ version = "3.1.0"
 description = "Python datetimes made easy"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "pendulum-3.1.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:aa545a59e6517cf43597455a6fb44daa4a6e08473d67a7ad34e4fa951efb9620"},
     {file = "pendulum-3.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:299df2da6c490ede86bb8d58c65e33d7a2a42479d21475a54b467b03ccb88531"},
@@ -2826,7 +2844,7 @@ version = "11.3.0"
 description = "Python Imaging Library (Fork)"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "pillow-11.3.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:1b9c17fd4ace828b3003dfd1e30bff24863e0eb59b535e8f80194d9cc7ecf860"},
     {file = "pillow-11.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:65dc69160114cdd0ca0f35cb434633c75e8e7fad4cf855177a05bf38678f73ad"},
@@ -2968,7 +2986,7 @@ version = "6.5.0"
 description = "An open-source interactive data visualization library for Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "plotly-6.5.0-py3-none-any.whl", hash = "sha256:5ac851e100367735250206788a2b1325412aa4a4917a4fe3e6f0bc5aa6f3d90a"},
     {file = "plotly-6.5.0.tar.gz", hash = "sha256:d5d38224883fd38c1409bef7d6a8dc32b74348d39313f3c52ca998b8e447f5c8"},
@@ -3007,7 +3025,7 @@ version = "0.4.1"
 description = "Accelerated property cache"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "propcache-0.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7c2d1fa3201efaf55d730400d945b5b3ab6e672e100ba0f9a409d950ab25d7db"},
     {file = "propcache-0.4.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1eb2994229cc8ce7fe9b3db88f5465f5fd8651672840b2e426b88cdb1a30aac8"},
@@ -3139,7 +3157,7 @@ version = "6.33.2"
 description = ""
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "protobuf-6.33.2-cp310-abi3-win32.whl", hash = "sha256:87eb388bd2d0f78febd8f4c8779c79247b26a5befad525008e49a6955787ff3d"},
     {file = "protobuf-6.33.2-cp310-abi3-win_amd64.whl", hash = "sha256:fc2a0e8b05b180e5fc0dd1559fe8ebdae21a27e81ac77728fb6c42b12c7419b4"},
@@ -3280,12 +3298,12 @@ version = "2.23"
 description = "C parser in Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main", "dev", "integrations"]
 files = [
     {file = "pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934"},
     {file = "pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2"},
 ]
-markers = {main = "implementation_name != \"PyPy\" and platform_python_implementation != \"PyPy\"", dev = "implementation_name == \"pypy\""}
+markers = {main = "implementation_name != \"PyPy\" and platform_python_implementation != \"PyPy\"", dev = "implementation_name == \"pypy\"", integrations = "implementation_name != \"PyPy\" and platform_python_implementation != \"PyPy\""}
 
 [[package]]
 name = "pydantic"
@@ -3450,7 +3468,7 @@ version = "2.12.0"
 description = "Settings management using Pydantic"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809"},
     {file = "pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0"},
@@ -3474,7 +3492,7 @@ version = "0.9.1"
 description = "Widget for deck.gl maps"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "pydeck-0.9.1-py2.py3-none-any.whl", hash = "sha256:b3f75ba0d273fc917094fa61224f3f6076ca8752b93d46faf3bcfd9f9d59b038"},
     {file = "pydeck-0.9.1.tar.gz", hash = "sha256:f74475ae637951d63f2ee58326757f8d4f9cd9f2a457cf42950715003e2cb605"},
@@ -3509,7 +3527,7 @@ version = "2.10.1"
 description = "JSON Web Token implementation in Python"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb"},
     {file = "pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953"},
@@ -3557,7 +3575,7 @@ version = "1.2.1"
 description = "Read key-value pairs from a .env file and set them as environment variables"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61"},
     {file = "python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6"},
@@ -3572,7 +3590,7 @@ version = "0.0.20"
 description = "A streaming multipart parser for Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104"},
     {file = "python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13"},
@@ -3584,7 +3602,7 @@ version = "2025.2"
 description = "World timezone definitions, modern and historical"
 optional = false
 python-versions = "*"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00"},
     {file = "pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3"},
@@ -3596,7 +3614,7 @@ version = "311"
 description = "Python for Window Extensions"
 optional = false
 python-versions = "*"
-groups = ["main"]
+groups = ["main", "integrations"]
 markers = "sys_platform == \"win32\""
 files = [
     {file = "pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3"},
@@ -3627,7 +3645,7 @@ version = "6.0.3"
 description = "YAML parser and emitter for Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "PyYAML-6.0.3-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f"},
     {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4"},
@@ -3815,7 +3833,7 @@ version = "0.37.0"
 description = "JSON Referencing + Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231"},
     {file = "referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8"},
@@ -3832,7 +3850,7 @@ version = "2025.11.3"
 description = "Alternative regular expression module, to replace re."
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "regex-2025.11.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2b441a4ae2c8049106e8b39973bfbddfb25a179dda2bdb99b0eeb60c40a6a3af"},
     {file = "regex-2025.11.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2fa2eed3f76677777345d2f81ee89f5de2f5745910e805f7af7386a920fa7313"},
@@ -3998,7 +4016,7 @@ version = "0.30.0"
 description = "Python bindings to Rust's persistent data structures (rpds)"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288"},
     {file = "rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00"},
@@ -4123,7 +4141,7 @@ version = "1.8.0"
 description = "A set of python modules for machine learning and data mining"
 optional = false
 python-versions = ">=3.11"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "scikit_learn-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:146b4d36f800c013d267b29168813f7a03a43ecd2895d04861f1240b564421da"},
     {file = "scikit_learn-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:f984ca4b14914e6b4094c5d52a32ea16b49832c03bd17a110f004db3c223e8e1"},
@@ -4185,7 +4203,7 @@ version = "1.16.3"
 description = "Fundamental algorithms for scientific computing in Python"
 optional = false
 python-versions = ">=3.11"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "scipy-1.16.3-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:40be6cf99e68b6c4321e9f8782e7d5ff8265af28ef2cd56e9c9b2638fa08ad97"},
     {file = "scipy-1.16.3-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:8be1ca9170fcb6223cc7c27f4305d680ded114a1567c0bd2bfcbf947d1b17511"},
@@ -4264,7 +4282,7 @@ version = "1.5.4"
 description = "Tool to Detect Surrounding Shell"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
     {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
@@ -4288,7 +4306,7 @@ version = "5.0.2"
 description = "A pure Python implementation of a sliding window memory map manager"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e"},
     {file = "smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5"},
@@ -4300,7 +4318,7 @@ version = "1.3.1"
 description = "Sniff out which async library your code is running under"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
     {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
@@ -4312,7 +4330,7 @@ version = "3.0.4"
 description = "SSE plugin for Starlette"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "sse_starlette-3.0.4-py3-none-any.whl", hash = "sha256:32c80ef0d04506ced4b0b6ab8fe300925edc37d26f666afb1874c754895f5dc3"},
     {file = "sse_starlette-3.0.4.tar.gz", hash = "sha256:5e34286862e96ead0eb70f5ddd0bd21ab1f6473a8f44419dd267f431611383dd"},
@@ -4354,7 +4372,7 @@ version = "0.50.0"
 description = "The little ASGI library that shines."
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca"},
     {file = "starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca"},
@@ -4373,7 +4391,7 @@ version = "1.52.1"
 description = "A faster way to build and share data apps"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "streamlit-1.52.1-py3-none-any.whl", hash = "sha256:97fee2c3421d350fd65548e45a20f506ec1b651d78f95ecacbc0c2f9f838081c"},
     {file = "streamlit-1.52.1.tar.gz", hash = "sha256:b036a71866b893c97fdebaa2a2ebd21ebf2af7daea4b3abe783a57b26f55b3ca"},
@@ -4414,7 +4432,7 @@ version = "9.1.2"
 description = "Retry code until it succeeds"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138"},
     {file = "tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb"},
@@ -4430,7 +4448,7 @@ version = "3.6.0"
 description = "threadpoolctl"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb"},
     {file = "threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e"},
@@ -4442,7 +4460,7 @@ version = "0.12.0"
 description = "tiktoken is a fast BPE tokeniser for use with OpenAI's models"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "tiktoken-0.12.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:3de02f5a491cfd179aec916eddb70331814bd6bf764075d39e21d5862e533970"},
     {file = "tiktoken-0.12.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b6cfb6d9b7b54d20af21a912bfe63a2727d9cfa8fbda642fd8322c70340aad16"},
@@ -4516,7 +4534,7 @@ version = "0.22.1"
 description = ""
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "tokenizers-0.22.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:59fdb013df17455e5f950b4b834a7b3ee2e0271e6378ccb33aa74d178b513c73"},
     {file = "tokenizers-0.22.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:8d4e484f7b0827021ac5f9f71d4794aaef62b979ab7608593da22b1d2e3c4edc"},
@@ -4549,7 +4567,7 @@ version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
@@ -4561,7 +4579,7 @@ version = "6.5.4"
 description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main", "dev", "integrations"]
 files = [
     {file = "tornado-6.5.4-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:d6241c1a16b1c9e4cc28148b1cda97dd1c6cb4fb7068ac1bedc610768dff0ba9"},
     {file = "tornado-6.5.4-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2d50f63dda1d2cac3ae1fa23d254e16b5e38153758470e9956cbc3d813d40843"},
@@ -4583,7 +4601,7 @@ version = "4.67.1"
 description = "Fast, Extensible Progress Meter"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2"},
     {file = "tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2"},
@@ -4621,7 +4639,7 @@ version = "4.4.4"
 description = "Run-time type checker for Python"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "typeguard-4.4.4-py3-none-any.whl", hash = "sha256:b5f562281b6bfa1f5492470464730ef001646128b180769880468bd84b68b09e"},
     {file = "typeguard-4.4.4.tar.gz", hash = "sha256:3a7fd2dffb705d4d0efaed4306a704c89b9dee850b688f060a8b1615a79e5f74"},
@@ -4636,7 +4654,7 @@ version = "0.20.0"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "typer_slim-0.20.0-py3-none-any.whl", hash = "sha256:f42a9b7571a12b97dddf364745d29f12221865acef7a2680065f9bb29c7dc89d"},
     {file = "typer_slim-0.20.0.tar.gz", hash = "sha256:9fc6607b3c6c20f5c33ea9590cbeb17848667c51feee27d9e314a579ab07d1a3"},
@@ -4655,7 +4673,7 @@ version = "2.32.4.20250913"
 description = "Typing stubs for requests"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "types_requests-2.32.4.20250913-py3-none-any.whl", hash = "sha256:78c9c1fffebbe0fa487a418e0fa5252017e9c60d1a2da394077f1780f655d7e1"},
     {file = "types_requests-2.32.4.20250913.tar.gz", hash = "sha256:abd6d4f9ce3a9383f269775a9835a4c24e5cd6b9f647d64f88aa4613c33def5d"},
@@ -4698,7 +4716,7 @@ version = "2025.3"
 description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1"},
     {file = "tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7"},
@@ -4710,7 +4728,7 @@ version = "1.4.0"
 description = "ASCII transliterations of Unicode text"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "Unidecode-1.4.0-py3-none-any.whl", hash = "sha256:c3c7606c27503ad8d501270406e345ddb480a7b5f38827eafe4fa82a137f0021"},
     {file = "Unidecode-1.4.0.tar.gz", hash = "sha256:ce35985008338b676573023acc382d62c264f307c8f7963733405add37ea2b23"},
@@ -4740,7 +4758,7 @@ version = "0.38.0"
 description = "The lightning-fast ASGI server."
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 markers = "sys_platform != \"emscripten\""
 files = [
     {file = "uvicorn-0.38.0-py3-none-any.whl", hash = "sha256:48c0afd214ceb59340075b4a052ea1ee91c16fbc2a9b1469cca0e54566977b02"},
@@ -4760,7 +4778,7 @@ version = "6.0.0"
 description = "Filesystem events monitoring"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 markers = "platform_system != \"Darwin\""
 files = [
     {file = "watchdog-6.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d1cdb490583ebd691c012b3d6dae011000fe42edb7a82ece80965b42abd61f26"},
@@ -4816,7 +4834,7 @@ version = "1.22.0"
 description = "Yet another URL library"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "yarl-1.22.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c7bd6683587567e5a49ee6e336e0612bec8329be1b7d4c8af5687dcdeb67ee1e"},
     {file = "yarl-1.22.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5cdac20da754f3a723cceea5b3448e1a2074866406adeb4ef35b469d089adb8f"},
@@ -4961,7 +4979,7 @@ version = "3.23.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "integrations"]
 files = [
     {file = "zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e"},
     {file = "zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166"},
@@ -4978,4 +4996,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "42234d3c6e0925cbc10be978498a8e4a70e5b12fefbc1c9e65075eef971107a1"
+content-hash = "89d0bdd4a94e6c714fd722d577a55cc0aae09a2d1d40b66bbdd6040b4671e450"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ optional = true
 
 [tool.poetry.group.integrations.dependencies]
 lightningrod-ai = "^0.1.14"
+metaculus-bot-review = "^0.1.1"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Adds [metaculus-bot-review](https://github.com/LouisP96/metaculus-bot-review) to the optional `integrations` group, with instructions in `integrations/README.md`.

The package scores your bot's resolved forecasts and displays its reasoning on specific questions. It reads the reports the bot published as Metaculus comments, so there is nothing to set up beyond the `METACULUS_TOKEN` that is already required. No LLM spend is incurred.

```bash
poetry install --with integrations
poetry run bot-review review --resolved-since 30 --output review.json --summary review.md
poetry run bot-review show <POST_ID> --section research
```

I first proposed this as a PR into forecasting-tools (Metaculus/forecasting-tools#324). Ben suggested releasing it as its own package instead, so improvements are not gated on the library's release cycle, and putting the instructions here. It is now on [PyPI](https://pypi.org/project/metaculus-bot-review/), so this PR is only the integration.

### What is in it

| file | change |
| --- | --- |
| `pyproject.toml` | `metaculus-bot-review = "^0.1.1"` in the existing optional `integrations` group |
| `poetry.lock` | regenerated |
| `integrations/README.md` | a **Bot Review** section |
| `README.md` | a short pointer to it |
| `.github/workflows/review_bot.yaml` | weekly review, artifacts kept for 90 days |
| `.claude/skills/review-bot/SKILL.md` | a Claude Code skill that drives the whole loop and writes up what it finds |

It only runs on the schedule once the repo variable `REVIEW_BOT_ENABLED` is set to `true`.